### PR TITLE
Remove hardcoded port in integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2
 jobs:
   # This job is used as a template for each Node.js version.
-  build-node-common: &common-build
-    # This property is overridden by each job but is set because it's mandatory.
+  build-node-common:
+    &common-build # This property is overridden by each job but is set because it's mandatory.
     docker:
       - image: circleci/node
 
@@ -18,9 +18,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run: yarn install --frozen-lockfile
 
@@ -48,6 +48,11 @@ jobs:
     docker:
       - image: circleci/node:11
 
+  build-node-12:
+    <<: *common-build
+    docker:
+      - image: circleci/node:12
+
 workflows:
   version: 2
   build:
@@ -55,3 +60,4 @@ workflows:
       - build-node-8
       - build-node-10
       - build-node-11
+      - build-node-12


### PR DESCRIPTION
- Use an open port on the machine instead of the fixed port.
- Run tests also on Node 12